### PR TITLE
Remove `lodash` in favor of native `forEach`

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ const allUpdateCbs = new WeakMap()
 const allPreUpdateCbs = new WeakMap()
 const subscriptions = new WeakMap()
 
-const _ = require('lodash')
 let autorunFn = null
 const transactionStack = []
 const autorunsAfterTransaction = new Set()
@@ -67,12 +66,12 @@ const api = {
             oldValue: oTarget[sKey],
             newValue: vValue
           }
-          _.forEach(preUpdateCbs, (callback) => {
+          preUpdateCbs.forEach((callback) => {
             callback(change)
           })
           oTarget[sKey] = vValue
 
-          _.forEach(updateCbs, (callback) => {
+          updateCbs.forEach((callback) => {
             callback(change)
           })
           if (thisSubscriptions[sKey]) {
@@ -93,11 +92,11 @@ const api = {
           oldValue: oTarget[sKey],
           newValue: undefined
         }
-        _.forEach(preUpdateCbs, (callback) => {
+        preUpdateCbs.forEach((callback) => {
           callback(change)
         })
         const deleted = delete oTarget[sKey]
-        _.forEach(updateCbs, (callback) => {
+        updateCbs.forEach((callback) => {
           callback(change)
         })
         if (thisSubscriptions[sKey]) {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,5 @@
     "mobx": "^2.1.6",
     "standard": "^7.0.1"
   },
-  "dependencies": {
-    "lodash": "^4.12.0"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
As the title says: This PR removes `lodash` in favor of the native `forEach` function on arrays. 