### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
   },
   "homepage": "https://github.com/capaj/proxevable#readme",
   "devDependencies": {
-    "ava": "^0.14.0",
+    "ava": "^0.22.0",
     "benchmark": "^2.1.0",
-    "husky": "^0.11.4",
-    "mobx": "^2.1.6",
-    "standard": "^7.0.1"
+    "husky": "^0.14.3",
+    "mobx": "^3.2.2",
+    "standard": "^10.0.3"
   },
   "dependencies": {
     "lodash": "^4.12.0"

--- a/run-bench.js
+++ b/run-bench.js
@@ -70,7 +70,7 @@ function arraySuite () {
 
 // add tests
 suite.add('mobX create observable, autorun and dispose', function () {
-  let c = 0
+  let c = 0 // eslint-disable-line 
   const a = mobx.observable({g: 0})
   const disposer = mobx.autorun(() => {
     const ident = (v) => v
@@ -85,7 +85,7 @@ suite.add('mobX create observable, autorun and dispose', function () {
   a.g = 4
 })
   .add('proxevable create observable, autorun and dispose', function () {
-    let c = 0
+    let c = 0 // eslint-disable-line 
     const a = proxevable.observable({})
     const disposer = proxevable.autorun(() => {
       const ident = (v) => v

--- a/test/observable.spec.js
+++ b/test/observable.spec.js
@@ -85,4 +85,5 @@ test('unobserve', (t) => {
   })
   unobserve()
   a.b = 1
+  t.true(true)
 })


### PR DESCRIPTION
This PR upgrades all `devDependencies` and fixes deprecation warnings by ava.

When running the benchmark, I get lot's of out of bounds errors by mobx. Not sure what's causing this as the benchmark code seems to be correct.

```bash
[mobx.array] Attempt to read an array index (0) that is out of bounds (0). Please check length first. Out of bound indices will not be tracked by MobX
```

EDIT: Looks like the autorun code is to blame in the benchmarks